### PR TITLE
Added span inside radio label for use of pseudo classes and styling

### DIFF
--- a/fields/radio/field.php
+++ b/fields/radio/field.php
@@ -34,7 +34,8 @@
 				<?php if(empty($field['config']['inline'])){ ?>
 				<div class="radio">
 				<?php } ?>
-				<label<?php if(!empty($field['config']['inline'])){ ?> class="radio-inline"<?php } ?> data-label="<?php echo esc_attr( $option['label'] ); ?>" for="<?php echo esc_attr( $field_id . '_' . $option_key ); ?>"><input type="radio" id="<?php echo esc_attr( $field_id . '_' . $option_key ); ?>" data-field="<?php echo esc_attr( $field_base_id ); ?>" class="<?php echo esc_attr( $field_id . $req_class ); ?>" name="<?php echo esc_attr( $field_name ); ?>" value="<?php echo esc_attr( $option['value'] ); ?>" <?php if( $field_value == $option['value'] || $field_value == $option_key ){ ?>checked="checked"<?php } ?> <?php echo $field_required; ?>> <?php echo $option['label']; ?></label>&nbsp;
+				<input type="radio" id="<?php echo esc_attr( $field_id . '_' . $option_key ); ?>" data-field="<?php echo esc_attr( $field_base_id ); ?>" class="<?php echo esc_attr( $field_id . $req_class ); ?>" name="<?php echo esc_attr( $field_name ); ?>" value="<?php echo esc_attr( $option['value'] ); ?>" <?php if( $field_value == $option['value'] || $field_value == $option_key ){ ?>checked="checked"<?php } ?> <?php echo $field_required; ?>>
+				<label<?php if(!empty($field['config']['inline'])){ ?> class="radio-inline"<?php } ?> data-label="<?php echo esc_attr( $option['label'] ); ?>" for="<?php echo esc_attr( $field_id . '_' . $option_key ); ?>"><span></span><?php echo $option['label']; ?></label>&nbsp;
 				<?php if(empty($field['config']['inline'])){ ?>
 				</div>
 				<?php } ?>


### PR DESCRIPTION
-got the input radio out of the label for use of pseudo classes such as :before :after and element+element selector (the main reason is styling the input radio box)
-added a span inside the label for same reason above